### PR TITLE
Added "Code Block" Feature

### DIFF
--- a/content/developers/node-operators/validators/setup-sgx.md
+++ b/content/developers/node-operators/validators/setup-sgx.md
@@ -4,11 +4,6 @@ layout: ~/layouts/DocumentationLayout
 
 **Prepare your Hardware**
 
-TEST
-```vue
-test me
-```
-
 
 If you're running a local machine and not a cloud-based VM -
 
@@ -26,7 +21,7 @@ If you're running a local machine and not a cloud-based VM -
 
 Note: `sgx_linux_x64_driver_2.6.0_602374c.bin` is the latest driver as of July 13, 2020. Please check under https://download.01.org/intel-sgx/sgx-linux/ that this is still the case. If not, please send us a PR or notify us.
 
-```
+```vue
 #! /bin/bash
 
 UBUNTUVERSION$(lsb_release -r -s | cut -d '.' -f 1)
@@ -108,7 +103,7 @@ First, make sure you have Rust installed: https://www.rust-lang.org/tools/instal
 
 *   Once Rust is installed, install the `nightly` toolchain:
     
-    ```
+    ```vue
     rustup toolchain install nightly
     
     ```
@@ -118,7 +113,7 @@ Then you can use this script (or run the commands one-by-one), which was tested 
 
 **Install SGX SDK + Driver**
 
-```
+```vue
 #! /bin/bash
 
 UBUNTUVERSION$(lsb_release -r -s | cut -d '.' -f 1)
@@ -223,7 +218,7 @@ sudo apt install -y libsgx-enclave-common libsgx-enclave-common-dev libsgx-urts 
 
 Note that sometimes after a system reboot you'll need to reinstall the driver (usually after a kernel upgrade):
 
-```
+```vue
 sudo $HOME/.sgxsdk/sgx_linux_x64_driver_*.bin
 
 ```
@@ -247,12 +242,12 @@ First, make sure you have Rust installed: https://www.rust-lang.org/tools/instal
 
 *   Once Rust is installed, install the `nightly` toolchain:
 
-```
+```vue
 rustup toolchain install nightly
 
 ```
 
-```
+```vue
 sudo apt install -y libssl-dev protobuf-compiler
 cargo +nightly install fortanix-sgx-tools sgxs-tools
 
@@ -262,7 +257,7 @@ sgx-detect
 
 Should print at the end:
 
-```
+```vue
 ✔  Able to launch enclaves
    ✔  Debug mode
    ✔  Production mode (Intel whitelisted)
@@ -273,7 +268,7 @@ You're all set to start running SGX programs!
 
 **Compiling a `hello-rust` project:**
 
-```
+```vue
 git clone --depth 1 -b v1.1.2 git@github.com:apache/incubator-teaclave-sgx-sdk.git
 
 cd incubator-teaclave-sgx-sdk/samplecode/hello-rust
@@ -286,7 +281,7 @@ cd bin
 
 Should print somting similar to this:
 
-```
+```vue
 [+] Init Enclave Successful 2!
 This is a normal world string passed into Enclave!
 This is a in-Enclave Rust string!
@@ -303,21 +298,21 @@ supported sgx
 
 To uninstall the Intel(R) SGX Driver, run:
 
-```
+```vue
 sudo /opt/intel/sgxdriver/uninstall.sh
 
 ```
 
 The above command produces no output when it succeeds. If you want to verify that the driver has been uninstalled, you can run the following, which should print `SGX Driver NOT installed`:
 
-```
+```vue
 ls /dev/isgx &>/dev/null && echo "SGX Driver installed" || echo "SGX Driver NOT installed"
 
 ```
 
 To uninstall the SGX SDK, run:
 
-```
+```vue
 sudo "$HOME"/.sgxsdk/sgxsdk/uninstall.sh
 rm -rf "$HOME/.sgxsdk"
 
@@ -325,7 +320,7 @@ rm -rf "$HOME/.sgxsdk"
 
 To uninstall the rest of the dependencies, run:
 
-```
+```vue
 sudo apt purge -y libsgx-enclave-common libsgx-enclave-common-dev libsgx-urts sgx-aesm-service libsgx-uae-service libsgx-launch libsgx-aesm-launch-plugin libsgx-ae-le
 
 ```

--- a/content/developers/node-operators/validators/setup-sgx.md
+++ b/content/developers/node-operators/validators/setup-sgx.md
@@ -2,7 +2,12 @@
 layout: ~/layouts/DocumentationLayout
 ---
 
-# Prepare your Hardware
+**Prepare your Hardware**
+
+TEST
+```vue
+test me
+```
 
 
 If you're running a local machine and not a cloud-based VM -
@@ -11,13 +16,13 @@ If you're running a local machine and not a cloud-based VM -
 2.  Enable SGX (Software controlled is not enough)
 3.  Disable Secure Boot
 
-# Installation
+**Installation**
 
 
-# For Node Runners
+**For Node Runners**
 ---------------------------------------
 
-###  Install SGX
+**Install SGX**
 
 Note: `sgx_linux_x64_driver_2.6.0_602374c.bin` is the latest driver as of July 13, 2020. Please check under https://download.01.org/intel-sgx/sgx-linux/ that this is still the case. If not, please send us a PR or notify us.
 
@@ -94,10 +99,10 @@ sudo apt install -y $PSW_PACKAGES
 
 ```
 
-# For Enclave Developers
+**For Enclave Developers**
 ---------------------------------------------------
 
-###  Prerequisites
+**Prerequisites**
 
 First, make sure you have Rust installed: https://www.rust-lang.org/tools/install
 
@@ -111,7 +116,7 @@ First, make sure you have Rust installed: https://www.rust-lang.org/tools/instal
 
 Then you can use this script (or run the commands one-by-one), which was tested on Ubuntu 20.04 with SGX driver/sdk version 2.10 intended for Ubuntu 18.04:
 
-###  Install SGX SDK + Driver
+**Install SGX SDK + Driver**
 
 ```
 #! /bin/bash
@@ -223,20 +228,20 @@ sudo $HOME/.sgxsdk/sgx_linux_x64_driver_*.bin
 
 ```
 
-# Testing your SGX setup
+**Testing your SGX setup**
 
 
-# For Node Runners
+**For Node Runners**
 -----------------------------------------
 
-###  Run `secretd init-enclave`
+**Run `secretd init-enclave`**
 
 See https://github.com/enigmampc/SecretNetwork/blob/master/docs/validators-and-full-nodes/verify-sgx.md for a guide how to test your setup
 
-# For Contract Developers
+**For Contract Developers**
 -----------------------------------------------------
 
-###  using `sgx-detect`:
+**using `sgx-detect`:**
 
 First, make sure you have Rust installed: https://www.rust-lang.org/tools/install
 
@@ -266,7 +271,7 @@ You're all set to start running SGX programs!
 
 ```
 
-###  Compiling a `hello-rust` project:
+**Compiling a `hello-rust` project:**
 
 ```
 git clone --depth 1 -b v1.1.2 git@github.com:apache/incubator-teaclave-sgx-sdk.git
@@ -293,7 +298,7 @@ supported sgx
 
 ```
 
-# Uninstall
+**Uninstall**
 
 
 To uninstall the Intel(R) SGX Driver, run:

--- a/content/developers/node-operators/validators/sgx-compliance.md
+++ b/content/developers/node-operators/validators/sgx-compliance.md
@@ -35,7 +35,7 @@ Note: Not all offerings from these providers will work with SGX. Be sure to pay 
 3. Psychz
 4. [Packet.net c3.small](https://www.packet.com/cloud/servers/c3-small/)
 
-# Non-working Hardware
+**Non-working Hardware**
 
 This is a list of hardware that does not work even though they advertise SGX support.
 

--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -58,7 +58,12 @@ module.exports = {
   },
   transformers: {
     remark: {
-      // global remark options
+      externalLinksTarget: '_blank',
+      externalLinksRel: ['nofollow', 'noopener', 'noreferrer'],
+      anchorClassName: 'icon icon-link',
+      plugins: [
+        'gridsome-plugin-remark-prismjs-all',
+      ]
     },
   },
   chainWebpack(config) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3149,6 +3149,17 @@
         "restore-cursor": "^2.0.0"
       }
     },
+    "clipboard": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
+      "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
+      "optional": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -4069,6 +4080,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -5801,6 +5818,15 @@
         "minimatch": "~3.0.2"
       }
     },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "optional": true,
+      "requires": {
+        "delegate": "^3.1.2"
+      }
+    },
     "got": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -6038,6 +6064,43 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        }
+      }
+    },
+    "gridsome-plugin-remark-prismjs-all": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/gridsome-plugin-remark-prismjs-all/-/gridsome-plugin-remark-prismjs-all-0.3.5.tgz",
+      "integrity": "sha512-Rl4g2mHUh7m/pEEBEVRHClPlDdh/YGYYN6nePdKg9c7WEe7gCq8Z1vk5lJ/iV908zLid/eEhk9+dffgDtXCLFw==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "parse-numeric-range": "^0.0.2",
+        "prismjs": "^1.19.0",
+        "unist-util-visit": "^2.0.2"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.4.tgz",
+          "integrity": "sha512-3dF39j/u423v4BBQrk1AQ2Ve1FxY5W3JKwXxVFzBODQ6WEvccguhgp802qQLKSnxPODE6WuRZtV+ohlUg4meBA=="
+        },
+        "unist-util-visit": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+          "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^4.0.0",
+            "unist-util-visit-parents": "^3.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+          "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^4.0.0"
+          }
         }
       }
     },
@@ -8567,6 +8630,11 @@
         "error-ex": "^1.2.0"
       }
     },
+    "parse-numeric-range": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-0.0.2.tgz",
+      "integrity": "sha1-tPCdQTx6282Yf26SM8e0shDJOOQ="
+    },
     "parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
@@ -9411,6 +9479,14 @@
       "requires": {
         "lodash": "^4.17.20",
         "renderkid": "^2.0.4"
+      }
+    },
+    "prismjs": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.22.0.tgz",
+      "integrity": "sha512-lLJ/Wt9yy0AiSYBf212kK3mM5L8ycwlyTlSxHBAneXLR0nzFMlZ5y7riFPF3E33zXOF2IH95xdY5jIyZbM9z/w==",
+      "requires": {
+        "clipboard": "^2.0.0"
       }
     },
     "probe-image-size": {
@@ -10373,6 +10449,12 @@
       "requires": {
         "commander": "^2.8.1"
       }
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "optional": true
     },
     "semver": {
       "version": "5.7.1",
@@ -11650,6 +11732,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "optional": true
     },
     "to-arraybuffer": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@gridsome/vue-remark": "^0.2.5",
     "@lkmx/flare-legacy": "0.28.19",
     "gridsome": "^0.7.0",
+    "gridsome-plugin-remark-prismjs-all": "^0.3.5",
     "typeface-hind": "^1.1.13",
     "typeface-montserrat": "^1.1.13"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -31,6 +31,7 @@ import ColorPalette from '@/components/ColorPalette'
 
 require('typeface-hind');
 require('typeface-montserrat');
+require("gridsome-plugin-remark-prismjs-all/themes/night-owl.css");
 
 export default function (Vue, { router, head, isClient }) {
   openGraph.forEach(item => head.meta.push(item))


### PR DESCRIPTION
The previous sites build, learn, and secretnodes.org all had support for adding "Code blocks" so documentation that requires sharing code or commands is easier for end users to understand. This update adds the minimum changes required for "code blocks" to work. 

To add a code block all you must do is put ``` then new line, enter the code or commands you want in the block, then add the 3x ` again like on the first line.

this can be seen on the following md page.
raw : https://raw.githubusercontent.com/SecretFoundation/SecretWebsite/master/content/developers/node-operators/light-client-mainnet.md

primary link : https://github.com/SecretFoundation/SecretWebsite/blob/master/content/developers/node-operators/light-client-mainnet.md

Future updates can and should improve on the styling of these code blocks.